### PR TITLE
Bug: php8 will trigger deprecated error.

### DIFF
--- a/console/controllers/MigrationController.php
+++ b/console/controllers/MigrationController.php
@@ -494,7 +494,7 @@ SQL;
                 return [];
             }
             
-            return $this->filterKeyIndex($rows, $table);
+            return $this->filterKeyIndex($table, $rows);
         } catch (\Exception $e) {
             return;
         }
@@ -506,7 +506,7 @@ SQL;
      *
      * @return array
      */
-    public function filterKeyIndex(array $rows = [], $table)
+    public function filterKeyIndex($table, array $rows = [])
     {
         $return = [];
         foreach ($rows as $row) {


### PR DESCRIPTION
'Required parameter $table follows optional parameter $rows'